### PR TITLE
use macro in pug syntax

### DIFF
--- a/src/lib/pug-syntax.js
+++ b/src/lib/pug-syntax.js
@@ -42,7 +42,7 @@ const transform = function (ast) {
           const { obj, val, key, block, line, column } = node;
           const nodes = [
             !endBlock ? { type: 'Text', val: '{', line, column } : null,
-            { type: 'Text', val: `${obj}.map((${val}${key ? `, ${key}` : ''}) => (`, line, column },
+            { type: 'Text', val: `__macro.for(${obj}).map((${val}${key ? `, ${key}` : ''}) => (`, line, column },
             block,
             { type: 'Text', val: '))', line, column },
             !endBlock ? { type: 'Text', val: '}', line, column } : null,

--- a/test/pug-syntax.js
+++ b/test/pug-syntax.js
@@ -59,10 +59,10 @@ div
 
 @EXPECTED:
 <div>
-  {array.map(value => (
+  {__macro.for(array).map(value => (
     <div>{value}</div>
   ))}
-  {array.map((value, index) => (
+  {__macro.for(array).map((value, index) => (
     <div key={index}>{value}</div>
   ))}
 </div>


### PR DESCRIPTION
native pug syntax can iterate object,
but the old implementation only iterate array,
use macro can solve this issue.